### PR TITLE
Fix writing past the end of the _intg_time buffer

### DIFF
--- a/Digital_Light_ISL29035.cpp
+++ b/Digital_Light_ISL29035.cpp
@@ -42,7 +42,7 @@ DigitalLightISL29035::DigitalLightISL29035():
     _intg_time[0] = INTEGRATION_TIME0;
     _intg_time[1] = INTEGRATION_TIME1;
     _intg_time[2] = INTEGRATION_TIME2;
-    _intg_time[4] = INTEGRATION_TIME3;
+    _intg_time[3] = INTEGRATION_TIME3;
 
     _ranges[0] = FULL_SCALE_LUX_RANGE0;
     _ranges[1] = FULL_SCALE_LUX_RANGE1;


### PR DESCRIPTION
`_intg_time` is declared with a size of `4` here:
https://github.com/Seeed-Studio/Grove_Digital_Light_Sensor/blob/457fcf7454b02fb33d95b1154ce73c27e2346cb2/Digital_Light_ISL29035.h#L99

Yet during construction, the code writes to the 5th element:
https://github.com/Seeed-Studio/Grove_Digital_Light_Sensor/blob/457fcf7454b02fb33d95b1154ce73c27e2346cb2/Digital_Light_ISL29035.cpp#L45

It looks like a simple typo. This pull request corrects the off-by-one.